### PR TITLE
fix error handing of failed card search

### DIFF
--- a/client/src/components/profile/deckEditor/NewCardList.js
+++ b/client/src/components/profile/deckEditor/NewCardList.js
@@ -2,12 +2,23 @@ import React from "react";
 import NewCardTile from "./NewCardTile";
 
 const NewCardList = (props) => {
-  const { cards, setCards } = props;
+  const { cards, setCards, searchFailed } = props;
 
   const newCardTiles = props.newCards.map((card) => {
     return <NewCardTile key={card.id} card={card} cards={cards} setCards={setCards} />;
   });
-  return <div className="new-card-list">{newCardTiles}</div>;
+
+  let searchWarning;
+  if (searchFailed) {
+    searchWarning = <div>search failed: try searching by card name</div>;
+  }
+
+  return (
+    <div className="new-card-list">
+      {newCardTiles}
+      {searchWarning}
+    </div>
+  );
 };
 
 export default NewCardList;

--- a/client/src/components/profile/deckEditor/SearchBar.js
+++ b/client/src/components/profile/deckEditor/SearchBar.js
@@ -14,6 +14,10 @@ const SearchBar = (props) => {
       if (response) {
         const returnedCards = response;
         props.setNewCards(returnedCards);
+        props.setSearchFailed(false);
+      } else {
+        props.setNewCards([]);
+        props.setSearchFailed(true);
       }
     });
   };

--- a/client/src/components/profile/deckEditor/SearchBox.js
+++ b/client/src/components/profile/deckEditor/SearchBox.js
@@ -9,14 +9,22 @@ const SearchBox = (props) => {
 
   const [newCards, setNewCards] = useState([]);
   const [showStats, setShowStats] = useState(false);
+  const [searchFailed, setSearchFailed] = useState(false);
 
-  const newCardList = <NewCardList newCards={newCards} cards={cards} setCards={setCards} />;
+  const newCardList = (
+    <NewCardList
+      newCards={newCards}
+      cards={cards}
+      setCards={setCards}
+      searchFailed={searchFailed}
+    />
+  );
   const statsList = <StatsList cards={cards} />;
 
   return (
     <>
       <div className="search-box-top">
-        <SearchBar setNewCards={setNewCards} />
+        <SearchBar setNewCards={setNewCards} setSearchFailed={setSearchFailed} />
         <StatsButton showStats={showStats} setShowStats={setShowStats} />
       </div>
       {showStats ? statsList : newCardList}

--- a/server/src/routes/api/v1/newCardsRouter.js
+++ b/server/src/routes/api/v1/newCardsRouter.js
@@ -4,13 +4,11 @@ import ScryfallClient from "../../../apiClient/ScryfallClient.js";
 const newCardsRouter = new express.Router();
 
 newCardsRouter.get("/:name", async (req, res) => {
-  const name = req.params.name;
-  const cards = await ScryfallClient.searchByName(name);
-
   try {
+    const name = req.params.name;
+    const cards = await ScryfallClient.searchByName(name);
     res.status(200).json({ cards });
   } catch (error) {
-    console.log(error);
     res.status(500).json({ errors: error });
   }
 });


### PR DESCRIPTION
a failed search on the deckeditor page no longer crashes the app and displays a warning that the search failed